### PR TITLE
Added changes to call callBackEndSync only when all SQL transaction has been commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/nbproject/private/
+/nbproject/project.properties
+/nbproject/project.xml

--- a/client_src/webSqlSync.js
+++ b/client_src/webSqlSync.js
@@ -239,6 +239,7 @@ var DBSYNC = {
         XHR.overrideMimeType = 'application/json;charset=UTF-8';
         XHR.open("POST", self.serverUrl, true);
         XHR.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+        XHR.setRequestHeader("Accept-Encoding", "gzip, deflate");
         XHR.upload.addEventListener("progress", uploadProgressCallBack, false);
         XHR.addEventListener("progress", downloadProgressCallBack, false);
         XHR.onreadystatechange = function () {


### PR DESCRIPTION
The problem with the actual implementation is that the user clicks the big "Sync Now" button on the mobile web app, and it gets control back BEFORE all changes are actually on the db (all websql are async)

This commit fixes that, so the end callback is called only when the websql transaction is actually finished.
