### PR TITLE
provide the status of the sync request to the caller

### DIFF
--- a/src/webSqlSync.js
+++ b/src/webSqlSync.js
@@ -234,6 +234,7 @@ DBSYNC = {
 			self.syncResult.syncOK = false;
 			self.syncResult.codeStr = 'syncKoServer';
 			if (serverData) {
+				self.syncResult.status = serverData.status;
 				self.syncResult.message = serverData.message;
 			} else {
 				self.syncResult.message = 'No answer from the server';


### PR DESCRIPTION
Hi,

This allows us to view any HTTP error status code when calling the sync method.
It's used in the app.

Jeroen.
